### PR TITLE
[Android] `onChangeQuery` is not called

### DIFF
--- a/src/SearchBar.android.js
+++ b/src/SearchBar.android.js
@@ -60,7 +60,7 @@ export default class SearchBar extends React.PureComponent {
   }
 
   _handleClear = () => {
-    this.setState({ text: '' });
+    this._handleChangeText('')
   };
   _handleChangeText = text => {
     this.setState({ text });


### PR DESCRIPTION
https://github.com/react-navigation/search-layout/pull/6